### PR TITLE
Add support for coercion of primitives

### DIFF
--- a/src/codecs.ts
+++ b/src/codecs.ts
@@ -1,0 +1,64 @@
+import { FieldName } from "./fields";
+
+export abstract class BaseCodec<T> {
+    constructor(public suffix: string) {
+        this.encodeName = this.encodeName.bind(this)
+    }
+    encodeName(fieldName: FieldName<T>) {
+        return fieldName.toString() + ':' + this.suffix;
+    }
+    abstract decodeValue(value: FormDataEntryValue): T;
+}
+
+export interface Codec<T> extends BaseCodec<T> { }
+
+export class StrCodec extends BaseCodec<string> {
+    constructor() {
+        super('string')
+    }
+    decodeValue(value: FormDataEntryValue) {
+        if (typeof value === 'string') {
+            return value;
+        }
+        throw new Error(`Expected value to be string but found ${value}`);
+    }
+}
+
+export const strCodec = new StrCodec()
+export const asStr = strCodec.encodeName
+
+export class NumCodec extends BaseCodec<number> {
+    constructor() {
+        super('number')
+    }
+    decodeValue(value: FormDataEntryValue) {
+        if (typeof value === 'string') {
+            return Number(value)
+        }
+        throw new Error(`Expected value to be string but found ${value}`);
+    }
+}
+
+export const numCodec = new NumCodec()
+export const asNum = numCodec.encodeName
+
+export class BoolCodec extends BaseCodec<boolean> {
+    constructor() {
+        super('boolean')
+    }
+    decodeValue(value: FormDataEntryValue) {
+        return value === 'true' || value === 'on'
+    }
+}
+
+export const boolCodec = new BoolCodec()
+export const asBool = boolCodec.encodeName
+
+export const mapCodecsBySuffix = (codecs: Codec<unknown>[]) =>
+    Object.fromEntries(codecs.map(it => [it.suffix, it]))
+
+export const defaultCodecsBySuffix = mapCodecsBySuffix([
+    strCodec,
+    numCodec,
+    boolCodec
+])

--- a/src/extract_form.spec.ts
+++ b/src/extract_form.spec.ts
@@ -31,3 +31,18 @@ test('extractFormData', () => {
     expect(files.object).toBe(undefined);
     expect(files.array[0]).toBeInstanceOf(Blob);
 });
+
+test('extractFormData with codecs', () => {
+    const formdata = new FormData();
+
+    formdata.set('name:string', 'name');
+    formdata.set('age:number', '90');
+    formdata.set('active:boolean', 'on');
+
+    const { data, fields, files } = extractFormData(formdata);
+
+    expect(data.name).toBe('name');
+    expect(data.age).toBe(90);
+    expect(data.active).toBe(true);
+
+})

--- a/src/fields.spec.ts
+++ b/src/fields.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from 'vitest';
+import { asBool, asNum, asStr } from './codecs';
 import { fields } from './fields';
 
 test('fields', () => {
@@ -22,3 +23,23 @@ test('fields', () => {
         'arrayNested[2].date',
     );
 });
+
+test('fields with codec', () => {
+    type Data = {
+        object?: {
+            key: string;
+        };
+        isActive: boolean;
+        arrayNested: Array<{
+            id: number;
+        }>;
+    };
+
+    const f = fields<Data>();
+
+    expect(asBool(f.isActive), 'nested object').toBe('isActive:boolean');
+    expect(asStr(f.object.key), 'nested object').toBe('object.key:string');
+    expect(asNum(f.arrayNested(2).id), 'nested array').toBe(
+        'arrayNested[2].id:number',
+    );
+})

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
 export { fields } from './fields';
+export { asNum, asBool, asStr, Codec } from "./codecs"
 export { extractFormData } from './extract_form';

--- a/src/set.ts
+++ b/src/set.ts
@@ -25,6 +25,7 @@ export function set(obj: any, path: string, value: unknown) {
 type ParsedSegment =
     | { type: 'key'; key: string }
     | { type: 'index'; key: number };
+
 function parsePath(str: string) {
     const parsed: ParsedSegment[] = [];
 


### PR DESCRIPTION
This is the implementation of what I was proposing in https://github.com/david-plugge/typed-formdata/issues/8

This attempts to handle *only* coercions without going into full blown form validation. 

Because the core library supports only primitive coercions,  it does not need additional dependencies. It does however support passing in external codecs which can support additional coercions. 

Let me know if you think this fits into the scope of this library. 